### PR TITLE
#3855 AITバージョンアップ(2025年2月) eval_noise_score_aquavs

### DIFF
--- a/deploy/container/dockerfile
+++ b/deploy/container/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.13-slim-bullseye
+FROM python:3.10.16-slim-bullseye
 LABEL maintainer="AIST"
 
 ENV ROOT_USER=root

--- a/deploy/container/repository/ait.manifest.json
+++ b/deploy/container/repository/ait.manifest.json
@@ -2,7 +2,7 @@
   "name": "eval_noise_score_aquavs",
   "description": "モデルの安定性を評価するために、ノイズを付けたラベルで検証します。SVAEの潜在表現を使用し、入力データセット内の各サンプルの異常を測定する「ノイズスコア」を計測します。詳細については、元の論文「Pulastya, et al. Assessing the quality of the datasets by identifying mislabeled samples」(URL: https://dl.acm.org/doi/abs/10.1145/3487351.3488361)",
   "source_repository": "https://github.com/aistairc/Qunomon_AIT_eval_noise_score_aquavs",
-  "version": "1.3",
+  "version": "1.4",
   "quality": "https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/C-2機械学習モデルの安定性",
   "keywords": [
     "Evaluation"

--- a/deploy/container/repository/my_ait.py
+++ b/deploy/container/repository/my_ait.py
@@ -38,7 +38,7 @@
 
 # [uneditable]
 
-# In[1]:
+# In[ ]:
 
 
 # Determine whether to start AIT or jupyter by startup argument
@@ -89,12 +89,12 @@ if not is_ait_launch:
 
 
 if not is_ait_launch:
-    requirements_generator.add_package('numpy', '1.26.4')
-    requirements_generator.add_package('matplotlib', '3.9.4')
+    requirements_generator.add_package('numpy', '2.0.2')
+    requirements_generator.add_package('matplotlib', '3.10.0')
     requirements_generator.add_package('pandas', '2.2.3')
-    requirements_generator.add_package('scikit-learn', '1.6.0')
+    requirements_generator.add_package('scikit-learn', '1.6.1')
     requirements_generator.add_package('tensorflow', '2.18.0')
-    requirements_generator.add_package('scipy', '1.13.1')
+    requirements_generator.add_package('scipy', '1.15.1')
 
 
 # #### #3-3 [uneditable]
@@ -174,7 +174,7 @@ if not is_ait_launch:
 
     manifest_generator.set_ait_source_repository('https://github.com/aistairc/Qunomon_AIT_eval_noise_score_aquavs')
     manifest_generator.add_ait_licenses('Apache License Version 2.0')
-    manifest_generator.set_ait_version('1.3')
+    manifest_generator.set_ait_version('1.4')
     manifest_generator.add_ait_keywords('Evaluation')
     manifest_generator.set_ait_quality('https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/C-2機械学習モデルの安定性')
     

--- a/deploy/container/repository/requirements.txt
+++ b/deploy/container/repository/requirements.txt
@@ -1,7 +1,7 @@
-numpy==1.26.4
-matplotlib==3.9.4
+numpy==2.0.2
+matplotlib==3.10.0
 pandas==2.2.3
-scikit-learn==1.6.0
+scikit-learn==1.6.1
 tensorflow==2.18.0
-scipy==1.13.1
+scipy==1.15.1
 ./ait_sdk-0.1.24-py3-none-any.whl

--- a/develop/ait.manifest.json
+++ b/develop/ait.manifest.json
@@ -2,7 +2,7 @@
   "name": "eval_noise_score_aquavs",
   "description": "モデルの安定性を評価するために、ノイズを付けたラベルで検証します。SVAEの潜在表現を使用し、入力データセット内の各サンプルの異常を測定する「ノイズスコア」を計測します。詳細については、元の論文「Pulastya, et al. Assessing the quality of the datasets by identifying mislabeled samples」(URL: https://dl.acm.org/doi/abs/10.1145/3487351.3488361)",
   "source_repository": "https://github.com/aistairc/Qunomon_AIT_eval_noise_score_aquavs",
-  "version": "1.3",
+  "version": "1.4",
   "quality": "https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/C-2機械学習モデルの安定性",
   "keywords": [
     "Evaluation"

--- a/develop/my_ait.ipynb
+++ b/develop/my_ait.ipynb
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "deletable": false,
     "editable": false
@@ -147,8 +147,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
       "\u001b[0m"
      ]
     }
@@ -223,12 +223,12 @@
    "outputs": [],
    "source": [
     "if not is_ait_launch:\n",
-    "    requirements_generator.add_package('numpy', '1.26.4')\n",
-    "    requirements_generator.add_package('matplotlib', '3.9.4')\n",
+    "    requirements_generator.add_package('numpy', '2.0.2')\n",
+    "    requirements_generator.add_package('matplotlib', '3.10.0')\n",
     "    requirements_generator.add_package('pandas', '2.2.3')\n",
-    "    requirements_generator.add_package('scikit-learn', '1.6.0')\n",
+    "    requirements_generator.add_package('scikit-learn', '1.6.1')\n",
     "    requirements_generator.add_package('tensorflow', '2.18.0')\n",
-    "    requirements_generator.add_package('scipy', '1.13.1')"
+    "    requirements_generator.add_package('scipy', '1.15.1')"
    ]
   },
   {
@@ -253,9 +253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "jupyter-server 2.15.0 requires nbformat>=5.3.0, but you have nbformat 5.2.0 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
       "\u001b[0m"
      ]
     }
@@ -297,14 +295,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-12-26 11:57:16.098662: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
-      "2024-12-26 11:57:16.099227: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.\n",
-      "2024-12-26 11:57:16.101084: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.\n",
-      "2024-12-26 11:57:16.106260: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:477] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+      "2025-02-14 13:15:51.135912: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "2025-02-14 13:15:51.136393: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.\n",
+      "2025-02-14 13:15:51.138526: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.\n",
+      "2025-02-14 13:15:51.144277: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:477] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
       "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "E0000 00:00:1735181836.115691      29 cuda_dnn.cc:8310] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "E0000 00:00:1735181836.118245      29 cuda_blas.cc:1418] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "2024-12-26 11:57:16.128093: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "E0000 00:00:1739506551.154295      60 cuda_dnn.cc:8310] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "E0000 00:00:1739506551.157085      60 cuda_blas.cc:1418] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2025-02-14 13:15:51.167402: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
       "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     }
@@ -404,7 +402,7 @@
     "\n",
     "    manifest_generator.set_ait_source_repository('https://github.com/aistairc/Qunomon_AIT_eval_noise_score_aquavs')\n",
     "    manifest_generator.add_ait_licenses('Apache License Version 2.0')\n",
-    "    manifest_generator.set_ait_version('1.3')\n",
+    "    manifest_generator.set_ait_version('1.4')\n",
     "    manifest_generator.add_ait_keywords('Evaluation')\n",
     "    manifest_generator.set_ait_quality('https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/C-2機械学習モデルの安定性')\n",
     "    \n",
@@ -1033,33 +1031,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of mislabeled:  5996 out of 60000\n",
-      "Epoch 1/10\n"
+      "Number of mislabeled:  5996 out of 60000\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-12-26 11:57:18.633426: E external/local_xla/xla/stream_executor/cuda/cuda_driver.cc:152] failed call to cuInit: INTERNAL: CUDA error: Failed call to cuInit: UNKNOWN ERROR (303)\n"
+      "2025-02-14 13:15:54.059640: E external/local_xla/xla/stream_executor/cuda/cuda_driver.cc:152] failed call to cuInit: INTERNAL: CUDA error: Failed call to cuInit: UNKNOWN ERROR (303)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m38s\u001b[0m 24ms/step - Classifier_loss: 0.8236 - Decoder_loss: 0.0134 - loss: 0.8370 - val_Classifier_loss: 0.4544 - val_Decoder_loss: 0.0147 - val_loss: 0.4691 - learning_rate: 0.0010\n",
+      "Epoch 1/10\n",
+      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m43s\u001b[0m 28ms/step - Classifier_loss: 0.7596 - Decoder_loss: 0.0128 - loss: 0.7724 - val_Classifier_loss: 0.4702 - val_Decoder_loss: 0.0161 - val_loss: 0.4863 - learning_rate: 0.0010\n",
       "Epoch 2/10\n",
-      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m40s\u001b[0m 27ms/step - Classifier_loss: 0.4031 - Decoder_loss: 0.0161 - loss: 0.4192 - val_Classifier_loss: 0.4295 - val_Decoder_loss: 0.0146 - val_loss: 0.4440 - learning_rate: 5.0000e-04\n",
+      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m46s\u001b[0m 31ms/step - Classifier_loss: 0.3990 - Decoder_loss: 0.0161 - loss: 0.4151 - val_Classifier_loss: 0.4354 - val_Decoder_loss: 0.0149 - val_loss: 0.4503 - learning_rate: 5.0000e-04\n",
       "Epoch 3/10\n",
-      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m41s\u001b[0m 27ms/step - Classifier_loss: 0.3503 - Decoder_loss: 0.0165 - loss: 0.3667 - val_Classifier_loss: 0.4218 - val_Decoder_loss: 0.0164 - val_loss: 0.4382 - learning_rate: 3.3333e-04\n",
+      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m45s\u001b[0m 30ms/step - Classifier_loss: 0.3546 - Decoder_loss: 0.0168 - loss: 0.3713 - val_Classifier_loss: 0.4217 - val_Decoder_loss: 0.0145 - val_loss: 0.4362 - learning_rate: 3.3333e-04\n",
       "Epoch 4/10\n",
-      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m41s\u001b[0m 27ms/step - Classifier_loss: 0.3115 - Decoder_loss: 0.0172 - loss: 0.3287 - val_Classifier_loss: 0.4195 - val_Decoder_loss: 0.0162 - val_loss: 0.4358 - learning_rate: 2.5000e-04\n",
-      "Epoch 5/10\n",
-      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m42s\u001b[0m 28ms/step - Classifier_loss: 0.2649 - Decoder_loss: 0.0173 - loss: 0.2821 - val_Classifier_loss: 0.4392 - val_Decoder_loss: 0.0169 - val_loss: 0.4561 - learning_rate: 2.0000e-04\n",
+      "\u001b[1m1500/1500\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m45s\u001b[0m 30ms/step - Classifier_loss: 0.3001 - Decoder_loss: 0.0167 - loss: 0.3167 - val_Classifier_loss: 0.4282 - val_Decoder_loss: 0.0160 - val_loss: 0.4442 - learning_rate: 2.5000e-04\n",
       "\u001b[1m186/186\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m209/209\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
-      "\u001b[1m189/189\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
+      "\u001b[1m189/189\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 4ms/step\n",
       "\u001b[1m192/192\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m184/184\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m171/171\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
@@ -1079,10 +1075,10 @@
       "\u001b[1m186/186\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m186/186\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m209/209\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
-      "\u001b[1m189/189\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
-      "\u001b[1m192/192\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
+      "\u001b[1m189/189\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 4ms/step\n",
+      "\u001b[1m192/192\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 4ms/step\n",
       "\u001b[1m184/184\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
-      "\u001b[1m171/171\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m0s\u001b[0m 3ms/step\n",
+      "\u001b[1m171/171\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m184/184\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m195/195\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m185/185\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
@@ -1097,7 +1093,7 @@
       "\u001b[1m195/195\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m185/185\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m186/186\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
-      "\u001b[1m186/186\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
+      "\u001b[1m186/186\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 4ms/step\n",
       "\u001b[1m209/209\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m189/189\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
       "\u001b[1m192/192\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 3ms/step\n",
@@ -1221,7 +1217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.16"
   },
   "vscode": {
    "interpreter": {

--- a/tool/docker/jupyter/dockerfile
+++ b/tool/docker/jupyter/dockerfile
@@ -1,5 +1,5 @@
 # python3をベースにする
-FROM python:3.9.13
+FROM python:3.10.16
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
python3.9.13 → 3.10.16

numpy 1.26.4 → 2.0.2　(tensorflow 2.18.0をつかっているため。)
matplotlib 3.9.4 → 3.10.0
scikit-learn 1.6.0 → 1.6.1
scipy 1.13.1 → 1.15.1